### PR TITLE
getFailedScenarios from github branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "testrunner",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testrunner",
-      "version": "0.0.1",
+      "version": "0.0.7",
       "dependencies": {
-        "@types/node": "^20.3.3",
+        "axios": "^1.4.0",
         "save": "^2.9.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.1",
+        "@types/node": "^20.3.3",
         "@types/vscode": "^1.79.0",
         "@types/webpack-env": "^1.18.1",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
@@ -274,7 +275,8 @@
     "node_modules/@types/node": {
       "version": "20.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
-      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -869,6 +871,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -879,6 +886,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1254,6 +1271,17 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1375,6 +1403,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -1890,6 +1926,25 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -1897,6 +1952,19 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fresh": {
@@ -2972,7 +3040,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2981,7 +3048,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3550,6 +3616,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "2.0.1",
@@ -4898,7 +4969,8 @@
     "@types/node": {
       "version": "20.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
-      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.5.0",
@@ -5335,11 +5407,26 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -5598,6 +5685,14 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -5688,6 +5783,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -6092,6 +6192,11 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -6099,6 +6204,16 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fresh": {
@@ -6900,14 +7015,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -7341,6 +7454,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pump": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   "scripts": {
     "test": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/index.js",
     "pretest": "npm run compile-web",
+    "testGithubApi": "tsc && node ./dist/web/test/githubAPI.js",
     "vscode:prepublish": "npm run package-web",
     "compile-web": "webpack",
     "watch-web": "webpack --watch",
@@ -125,6 +126,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",
+    "@types/node": "^20.3.3",
     "@types/vscode": "^1.79.0",
     "@types/webpack-env": "^1.18.1",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
@@ -139,11 +141,10 @@
     "ts-loader": "^9.4.3",
     "typescript": "^5.1.3",
     "webpack": "^5.85.0",
-    "webpack-cli": "^5.1.1",
-    "@types/node": "^20.3.3"
+    "webpack-cli": "^5.1.1"
   },
   "dependencies": {
-
+    "axios": "^1.4.0",
     "save": "^2.9.0"
   }
 }

--- a/src/web/githubAPI.ts
+++ b/src/web/githubAPI.ts
@@ -1,0 +1,134 @@
+import axios from 'axios';
+
+interface FailedScenario {
+    feature: string;
+    scenario: string;
+}
+
+interface GithubApiResult {
+    data: GithubAPIData[];
+}
+
+interface GithubAPIData {
+    head: {
+        ref: string;
+    };
+    number: number;
+    body: string;
+
+}
+
+// Requires environment variable: GITHUB_TOKEN (requires repository scopes)
+export async function getFailedScenarios(branchName: string, repositoryApiUrl: string) {
+    console.log("Retrieving failed scenarios for branch" + branchName);
+
+
+    const branchId = await getBranchIdFromName(branchName, repositoryApiUrl);
+    if (branchId === -1) {
+        console.error(`Branch ${branchName} with url ${repositoryApiUrl} could not be found!`);
+        process.exit(1);
+    }
+
+    const comments = await getCommentsForBranch(repositoryApiUrl, branchId);
+    const pipelineReportComments = await commentsShouldStartWith("## Pipeline Report", comments);
+    const pipelineReportString = pipelineReportComments[0].body;
+
+    const scenarios = splitByScenario(pipelineReportString);
+
+    const failedScenarios: FailedScenario[] = [];
+
+    for (const scenario of scenarios) {
+        const scenarioName = getScenarioName(scenario);
+        if (!scenarioName) {
+            continue;
+        }
+
+        const featureName = getFeatureNameFrom(scenario);
+
+        failedScenarios.push({
+            feature: featureName,
+            scenario: scenarioName
+        });
+
+    }
+
+    console.log(`Found ${failedScenarios.length} failed scenarios`);
+    return failedScenarios;
+
+}
+
+async function getBranchIdFromName(branchName: string, repositoryUrl: string): Promise<number> {
+    const url = `${repositoryUrl}/pulls?state=open`;
+
+    const response = await axios.get(url, {
+        headers: {
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            "Content-Type": "application/json",
+        }
+    }).then((response) => {
+        return response;
+    }).catch((error) => {
+        console.error(`Request was not successful: ${error}`);
+        return -1;
+    });
+
+    const resultList = (response as GithubApiResult).data;
+    const branch = resultList.filter((result) => result.head.ref === branchName);
+    if (branch.length === 0) {
+        console.error(`No branch found for ${branchName}`);
+        return -1;
+    }
+    const branchId = branch[0].number;
+    console.log(`Branch id found: ${branchId}`);
+    return branchId;
+}
+
+async function getCommentsForBranch(repositoryUrl: string, branchId: number): Promise<GithubAPIData[]> {
+    const url = `${repositoryUrl}/issues/${branchId}/comments`;
+    // ## Pipeline Report
+    const response = await axios.get(url, {
+        headers: {
+            Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            "Content-Type": "application/json",
+        }
+    }).then((response) => {
+        return response;
+    }).catch((error) => {
+        console.error(`Request was not successful: ${error}`);
+        return -1;
+    });
+
+    return (response as GithubApiResult).data;
+}
+
+async function commentsShouldStartWith(filterCriteria: string, comments: GithubAPIData[]): Promise<GithubAPIData[]> {
+    const filteredComment = comments.filter((comment) => {
+        return comment.body.startsWith(filterCriteria);
+    });
+    return filteredComment;
+}
+
+function splitByScenario(stringToSplit: string): string[] {
+    // 1. Split by --- (each scenario)
+    return stringToSplit.split("---");
+}
+
+function getScenarioName(scenario: string): string {
+    // 2. Regex for scenario name: \|Scenario\|(.*)\|   and trim()
+    const scenarioRegex = /\|Scenario\|(.*)\| /gm;
+    const scenarioName = scenarioRegex.exec(scenario);
+    if (scenarioName !== null && scenarioName.length > 1) {
+        return scenarioName[1].trim();
+    }
+    return "";
+}
+
+function getFeatureNameFrom(scenario: string): string {
+    // 2. Regex for scenario name: \|Scenario\|(.*)\|   and trim()
+    const featureRegex = /\|.?Feature\|(.*)\| /gm;
+    const featureName = featureRegex.exec(scenario);
+    if (featureName !== null && featureName.length > 1) {
+        return featureName[1].trim();
+    }
+    return "";
+}

--- a/src/web/test/githubAPI.ts
+++ b/src/web/test/githubAPI.ts
@@ -1,6 +1,6 @@
 
 import { getFailedScenarios } from "../githubAPI";
 
-getFailedScenarios("poc/placeholder1", process.env.REPOSITORY_URL ?? '');
+getFailedScenarios("<insert actual branchName>", process.env.REPOSITORY_URL ?? '');
 
 

--- a/src/web/test/githubAPI.ts
+++ b/src/web/test/githubAPI.ts
@@ -1,0 +1,6 @@
+
+import { getFailedScenarios } from "../githubAPI";
+
+getFailedScenarios("poc/placeholder1", process.env.REPOSITORY_URL ?? '');
+
+


### PR DESCRIPTION
The *getFailedScenarios* function requires the branchName and full repository api url (as this should not be hardcoded and pushed to github).
The github token used for authentication of the github api is consumed as the environment variable *GITHUB_TOKEN* multiple times in subfunctions. 

Add the following in the launch.json and update a real branch inside`src/web/test/githubAPI.ts` in order to test manually:
```
		{
			"name": "Test GithubApi",
			"request": "launch",
			"runtimeArgs": [
				"run-script",
				"testGithubApi"
			],
			"runtimeExecutable": "npm",
			"skipFiles": [
				"<node_internals>/**"
			],
			"type": "node",
			"env": {
				"REPOSITORY_URL": "",
				"GITHUB_TOKEN": ""
			}
		},
```